### PR TITLE
chore(release): Bumping version for release

### DIFF
--- a/ipyauth/__meta__.py
+++ b/ipyauth/__meta__.py
@@ -19,11 +19,11 @@ __name__ = 'ipyauth'
 name_url = __name__.replace('_', '-')
 
 
-version_info = (0, 2, 6)
+version_info = (0, 3, 0)
 __version__ = _get_version(version_info)
 
 # must be MANUALLY synced wih js.package.json.version
-version_js_info = (0, 2, 6)
+version_js_info = (0, 3, 0)
 __version_js__ = _get_version(version_js_info)
 
 

--- a/ipyauth/js/package-lock.json
+++ b/ipyauth/js/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "ipyauth",
-    "version": "0.2.6",
+    "version": "0.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ipyauth/js/package.json
+++ b/ipyauth/js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ipyauth",
-    "version": "0.2.6",
+    "version": "0.3.0",
     "description": "A Custom Jupyter Widget Library",
     "author": "oscar6echo",
     "license": "MIT",


### PR DESCRIPTION
Will merge and release once: https://github.com/optimizely/ipyauth/pull/4 and https://github.com/optimizely/ipyauth/pull/5 are merged.